### PR TITLE
Extending the ikev2TransformTypes property

### DIFF
--- a/schema/bom-1.6.schema.json
+++ b/schema/bom-1.6.schema.json
@@ -5564,34 +5564,39 @@
               "additionalProperties": false,
               "properties": {
                 "encr": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "Encryption Algorithm (ENCR)",
+                  "type": "array",
+                  "$ref": "#/definitions/ikeV2Enc",
+                  "title": "Encryption Algorithms (ENCR)",
                   "description": "Transform Type 1: encryption algorithms"
                 },
                 "prf": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "Pseudorandom Function (PRF)",
+                  "type": "array",
+                  "$ref": "#/definitions/ikeV2Prf",
+                  "title": "Pseudorandom Functions (PRF)",
                   "description": "Transform Type 2: pseudorandom functions"
                 },
                 "integ": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "Integrity Algorithm (INTEG)",
+                  "type": "array",
+                  "$ref": "#/definitions/ikeV2Integ",
+                  "title": "Integrity Algorithms (INTEG)",
                   "description": "Transform Type 3: integrity algorithms"
                 },
                 "ke": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "Key Exchange Method (KE)",
+                  "type": "array",
+                  "$ref": "#/definitions/ikeV2Ke",
+                  "title": "Key Exchange Methods (KE)",
                   "description": "Transform Type 4: Key Exchange Method (KE) per [RFC 9370](https://www.ietf.org/rfc/rfc9370.html), formerly called Diffie-Hellman Group (D-H)."
                 },
                 "esn": {
                   "type": "boolean",
-                  "title": "Extended Sequence Numbers (ESN)",
+                  "title": "Extended Sequence Number (ESN)",
                   "description": "Specifies if an Extended Sequence Number (ESN) is used."
                 },
                 "auth": {
-                  "$ref": "#/definitions/cryptoRefArray",
-                  "title": "IKEv2 Authentication method",
-                  "description": "IKEv2 Authentication method"
+                  "type": "array",
+                  "$ref": "#/definitions/ikeV2Auth",
+                  "title": "IKEv2 Authentication methods",
+                  "description": "IKEv2 Authentication method per [RFC9593](https://www.ietf.org/rfc/rfc9593.html)."
                 }
               }
             },
@@ -5645,6 +5650,135 @@
               "0xC0",
               "0x9E"
             ]
+          }
+        }
+      }
+    },
+    "ikeV2Enc": {
+      "type": "object",
+      "title": "Encryption Algorithm (ENCR)",
+      "description": "Object representing an encryption algorithm (ENCR)",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the encryption method.",
+          "examples": [
+            "ENCR_AES_GCM_16"
+          ]
+        },
+        "algorithms": {
+          "type": "array",
+          "title": "Related Algorithms",
+          "description": "A list of algorithms related to the cipher suite.",
+          "items": {
+            "$ref": "#/definitions/refType",
+            "title": "Algorithm reference",
+            "description": "The bom-ref to algorithm cryptographic asset."
+          }
+        },
+        "keyLength": {
+          "type": "integer",
+          "title": "Encryption algorithm key length",
+          "description": "The key length of the encryption algorithm."
+        }
+      }
+    },
+    "ikeV2Prf": {
+      "type": "object",
+      "title": "Pseudorandom Function (PRF)",
+      "description": "Object representing a pseudorandom function (PRF)",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the pseudorandom function.",
+          "examples": [
+            "PRF_HMAC_SHA2_256"
+          ]
+        },
+        "algorithms": {
+          "type": "array",
+          "title": "Related Algorithms",
+          "description": "A list of algorithms related to the pseudorandom function.",
+          "items": {
+            "$ref": "#/definitions/refType",
+            "title": "Algorithm reference",
+            "description": "The bom-ref to algorithm cryptographic asset."
+          }
+        }
+      }
+    },
+    "ikeV2Integ": {
+      "type": "object",
+      "title": "Integrity Algorithm (INTEG)",
+      "description": "Object representing a Integrity Algorithm (INTEG)",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the Integrity Algorithm.",
+          "examples": [
+            "AUTH_HMAC_SHA2_256_128"
+          ]
+        },
+        "algorithms": {
+          "type": "array",
+          "title": "Related Algorithms",
+          "description": "A list of algorithms related to the Integrity Algorithm.",
+          "items": {
+            "$ref": "#/definitions/refType",
+            "title": "Algorithm reference",
+            "description": "The bom-ref to algorithm cryptographic asset."
+          }
+        }
+      }
+    },
+    "ikeV2Ke": {
+      "type": "object",
+      "title": "Key Exchange Method (KE)",
+      "description": "Object representing a Key Exchange Method (KE)",
+      "additionalProperties": false,
+      "properties": {
+        "group": {
+          "type": "integer",
+          "title": "Group Identifier",
+          "description": "A group identifier for the Key exchange algorithm."
+        },
+        "algorithms": {
+          "type": "array",
+          "title": "Related Algorithms",
+          "description": "A list of algorithms related to the Key Exchange Method.",
+          "items": {
+            "$ref": "#/definitions/refType",
+            "title": "Algorithm reference",
+            "description": "The bom-ref to algorithm cryptographic asset."
+          }
+        }
+      }
+    },
+    "ikeV2Auth": {
+      "type": "object",
+      "title": "IKEv2 Authentication method",
+      "description": "Object representing a IKEv2 Authentication method",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the Authentication method."
+        },
+        "algorithms": {
+          "type": "array",
+          "title": "Related Algorithms",
+          "description": "A list of algorithms related to the IKEv2 Authentication method.",
+          "items": {
+            "$ref": "#/definitions/refType",
+            "title": "Algorithm reference",
+            "description": "The bom-ref to algorithm cryptographic asset."
           }
         }
       }


### PR DESCRIPTION
Allows for the representation of both IKEv2-specific names for ENCR, PRF, INTEG, KE, and AUTH, as well as the specification of an array of related algorithms through BOM references.