### PR TITLE
IKE transform types: Only one algorithm per parameter

### DIFF
--- a/schema/bom-1.7.schema.json
+++ b/schema/bom-1.7.schema.json
@@ -5894,20 +5894,15 @@
             "ENCR_AES_GCM_16"
           ]
         },
-        "algorithms": {
-          "type": "array",
-          "title": "Related Algorithms",
-          "description": "A list of algorithms related to the cipher suite.",
-          "items": {
-            "$ref": "#/definitions/refType",
-            "title": "Algorithm reference",
-            "description": "The bom-ref to algorithm cryptographic asset."
-          }
-        },
         "keyLength": {
           "type": "integer",
           "title": "Encryption algorithm key length",
           "description": "The key length of the encryption algorithm."
+        },
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
         }
       }
     },
@@ -5925,64 +5920,49 @@
             "PRF_HMAC_SHA2_256"
           ]
         },
-        "algorithms": {
-          "type": "array",
-          "title": "Related Algorithms",
-          "description": "A list of algorithms related to the pseudorandom function.",
-          "items": {
-            "$ref": "#/definitions/refType",
-            "title": "Algorithm reference",
-            "description": "The bom-ref to algorithm cryptographic asset."
-          }
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
         }
       }
     },
     "ikeV2Integ": {
       "type": "object",
       "title": "Integrity Algorithm (INTEG)",
-      "description": "Object representing a Integrity Algorithm (INTEG)",
+      "description": "Object representing an integrity algorithm (INTEG)",
       "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
           "title": "Name",
-          "description": "A name for the Integrity Algorithm.",
+          "description": "A name for the integrity algorithm.",
           "examples": [
             "AUTH_HMAC_SHA2_256_128"
           ]
         },
-        "algorithms": {
-          "type": "array",
-          "title": "Related Algorithms",
-          "description": "A list of algorithms related to the Integrity Algorithm.",
-          "items": {
-            "$ref": "#/definitions/refType",
-            "title": "Algorithm reference",
-            "description": "The bom-ref to algorithm cryptographic asset."
-          }
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
         }
       }
     },
     "ikeV2Ke": {
       "type": "object",
       "title": "Key Exchange Method (KE)",
-      "description": "Object representing a Key Exchange Method (KE)",
+      "description": "Object representing a key exchange method (KE)",
       "additionalProperties": false,
       "properties": {
         "group": {
           "type": "integer",
           "title": "Group Identifier",
-          "description": "A group identifier for the Key exchange algorithm."
+          "description": "A group identifier for the key exchange algorithm."
         },
-        "algorithms": {
-          "type": "array",
-          "title": "Related Algorithms",
-          "description": "A list of algorithms related to the Key Exchange Method.",
-          "items": {
-            "$ref": "#/definitions/refType",
-            "title": "Algorithm reference",
-            "description": "The bom-ref to algorithm cryptographic asset."
-          }
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
         }
       }
     },
@@ -5995,17 +5975,12 @@
         "name": {
           "type": "string",
           "title": "Name",
-          "description": "A name for the Authentication method."
+          "description": "A name for the authentication method."
         },
-        "algorithms": {
-          "type": "array",
-          "title": "Related Algorithms",
-          "description": "A list of algorithms related to the IKEv2 Authentication method.",
-          "items": {
-            "$ref": "#/definitions/refType",
-            "title": "Algorithm reference",
-            "description": "The bom-ref to algorithm cryptographic asset."
-          }
+        "algorithm": {
+          "$ref": "#/definitions/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
         }
       }
     },


### PR DESCRIPTION
Can't seem to open issues against this repo, so I describe the issue here.

In IKEv2 each transform-type parameter refers to exactly one algorithm. The current CBOM spec draft, however, associates an array of algorithms with each parameter.

This PR replaces each of these arrays with an individual bom-ref. The spec still has arrays of parameters, just each parameter has only one algorithm.